### PR TITLE
Add generated number as parameter for onSuccess

### DIFF
--- a/src/common.coffee
+++ b/src/common.coffee
@@ -252,7 +252,7 @@ class EAN13
           context.fillStyle = 'red'
           context.fill()
 
-      @settings.onSuccess.call()
+      @settings.onSuccess.call(this, @number)
     else
       #call error callback
       @settings.onError.call(this, "canvas context is null")


### PR DESCRIPTION
Returns generated code in onSuccess callback, if some more action requires it on page.
Most useful if entered 12 digits, as it returns valid EAN13 code, with checksum.